### PR TITLE
Replace <main> with <section>

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "svelteSortOrder": "scripts-markup-styles",
+  "svelteStrictMode": false,
+  "svelteBracketNewLine": true,
+  "svelteAllowShorthand": true,
+  "svelteIndentScriptAndStyle": true
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
+  "semi": false,
   "svelteSortOrder": "scripts-markup-styles",
   "svelteStrictMode": false,
   "svelteBracketNewLine": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,21 @@
 {
   "name": "svelte-simple-datatables",
-  "version": "0.1.17",
+  "version": "0.1.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@rollup/plugin-node-resolve": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-6.1.0.tgz",
-      "integrity": "sha512-Cv7PDIvxdE40SWilY5WgZpqfIUEaDxFxs89zCAHjqyRwlTSuql4M5hjIuc5QYJkOH0/vyiyNXKD72O+LhRipGA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-10.0.0.tgz",
+      "integrity": "sha512-sNijGta8fqzwA1VwUEtTvWCx2E7qC70NMsDh4ZG13byAXYigBNZMxALhKUSycBks5gupJdq0lFrKumFrRZ8H3A==",
       "dev": true,
       "requires": {
-        "@rollup/pluginutils": "^3.0.0",
-        "@types/resolve": "0.0.8",
+        "@rollup/pluginutils": "^3.1.0",
+        "@types/resolve": "1.17.1",
         "builtin-modules": "^3.1.0",
+        "deepmerge": "^4.2.2",
         "is-module": "^1.0.0",
-        "resolve": "^1.11.1"
+        "resolve": "^1.17.0"
       }
     },
     "@rollup/pluginutils": {
@@ -35,25 +36,19 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.0.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.14.tgz",
-      "integrity": "sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ==",
+      "version": "14.14.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.7.tgz",
+      "integrity": "sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg==",
       "dev": true
     },
     "@types/resolve": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
-      "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+      "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
       "dev": true,
       "requires": {
         "@types/node": "*"
       }
-    },
-    "acorn": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
-      "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
-      "dev": true
     },
     "builtin-modules": {
       "version": "3.1.0",
@@ -61,11 +56,48 @@
       "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
       "dev": true
     },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "dev": true
+    },
     "estree-walker": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
       "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
       "dev": true
+    },
+    "fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "dev": true,
+      "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "is-core-module": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.1.0.tgz",
+      "integrity": "sha512-YcV7BgVMRFRua2FqQzKtTDMz8iCuLEyGKjr70q8Zm1yy2qKcurbFEd79PAdHV77oL3NrAaOVQIbMmiHQCHB7ZA==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
     },
     "is-module": {
       "version": "1.0.0",
@@ -92,29 +124,28 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
       "dev": true,
       "requires": {
+        "is-core-module": "^2.1.0",
         "path-parse": "^1.0.6"
       }
     },
     "rollup": {
-      "version": "1.32.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
-      "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+      "version": "2.33.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.33.1.tgz",
+      "integrity": "sha512-uY4O/IoL9oNW8MMcbA5hcOaz6tZTMIh7qJHx/tzIJm+n1wLoY38BLn6fuy7DhR57oNFLMbDQtDeJoFURt5933w==",
       "dev": true,
       "requires": {
-        "@types/estree": "*",
-        "@types/node": "*",
-        "acorn": "^7.1.0"
+        "fsevents": "~2.1.2"
       }
     },
     "rollup-plugin-svelte": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-svelte/-/rollup-plugin-svelte-5.2.3.tgz",
-      "integrity": "sha512-513vOht9A93OV7fvmpIq8mD1JFgTZ5LidmpULKM2Od9P1l8oI5KwvO32fwCnASuVJS1EkRfvCnS7vKQ8DF4srg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-svelte/-/rollup-plugin-svelte-6.1.1.tgz",
+      "integrity": "sha512-ijnm0pH1ScrY4uxwaNXBpNVejVzpL2769hIEbAlnqNUWZrffLspu5/k9/l/Wsj3NrEHLQ6wCKGagVJonyfN7ow==",
       "dev": true,
       "requires": {
         "require-relative": "^0.8.7",
@@ -146,9 +177,9 @@
       "dev": true
     },
     "svelte": {
-      "version": "3.29.4",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.29.4.tgz",
-      "integrity": "sha512-oW0fGHlyFFMvzRtIvOs84b0fOc0gmZNQcL5Is3hxuTpvaYX3pfd8oHy4KnOvbq4Ca6SG6AHdRMk7OhApTo0NqA==",
+      "version": "3.29.7",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.29.7.tgz",
+      "integrity": "sha512-rx0g311kBODvEWUU01DFBUl3MJuJven04bvTVFUG/w0On/wuj0PajQY/QlXcJndFxG+W1s8iXKaB418tdHWc3A==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@rollup/plugin-node-resolve": "^6.0.0",
-    "rollup": "^1.20.0",
-    "rollup-plugin-svelte": "^5.0.0",
-    "svelte": "^3.29.4"
+    "@rollup/plugin-node-resolve": "^10.0.0",
+    "rollup": "^2.33.1",
+    "rollup-plugin-svelte": "^6.1.1",
+    "svelte": "^3.29.7"
   },
   "keywords": [
     "svelte table datatable simple-datatables"

--- a/src/Datatable.svelte
+++ b/src/Datatable.svelte
@@ -1,24 +1,24 @@
 <script>
-  import { options } from "./stores/options.js";
-  import { datatable } from "./datatable.js";
-  import Search from "./components/Search.svelte";
-  import Pagination from "./components/Pagination.svelte";
-  import Header from "./components/Header.svelte";
-  import { onMount, onDestroy } from "svelte";
-  export let data = [];
-  export let settings = {};
+  import { options } from "./stores/options.js"
+  import { datatable } from "./datatable.js"
+  import Search from "./components/Search.svelte"
+  import Pagination from "./components/Pagination.svelte"
+  import Header from "./components/Header.svelte"
+  import { onMount, onDestroy } from "svelte"
+  export let data = []
+  export let settings = {}
   $: {
-    datatable.setRows(data);
-    options.update(settings);
+    datatable.setRows(data)
+    options.update(settings)
   }
   onMount(() => {
-    datatable.addEventScrollX();
-    datatable.resize();
+    datatable.addEventScrollX()
+    datatable.resize()
     new ResizeObserver((mutations) => {
-      datatable.resize();
-    }).observe(document.querySelector("main.datatable").parentElement);
-  });
-  onDestroy(() => datatable.reset());
+      datatable.resize()
+    }).observe(document.querySelector("main.datatable").parentElement)
+  })
+  onDestroy(() => datatable.reset())
 </script>
 
 <section class="datatable">

--- a/src/Datatable.svelte
+++ b/src/Datatable.svelte
@@ -1,50 +1,77 @@
 <script>
-    import { options } from './stores/options.js'
-    import { datatable } from './datatable.js'
-    import Search from './components/Search.svelte'
-    import Pagination from './components/Pagination.svelte'
-    import Header from './components/Header.svelte'
-    import { onMount, onDestroy } from 'svelte'
-    export let data = []
-    export let settings = {}
-    $: { 
-        datatable.setRows(data)  
-        options.update(settings)
-    }
-    onMount( () => {
-        datatable.addEventScrollX()
-        datatable.resize()
-        new ResizeObserver( mutations => {
-            datatable.resize()
-        }).observe( document.querySelector('main.datatable').parentElement )
-    })
-    onDestroy( () => datatable.reset() )
+  import { options } from "./stores/options.js";
+  import { datatable } from "./datatable.js";
+  import Search from "./components/Search.svelte";
+  import Pagination from "./components/Pagination.svelte";
+  import Header from "./components/Header.svelte";
+  import { onMount, onDestroy } from "svelte";
+  export let data = [];
+  export let settings = {};
+  $: {
+    datatable.setRows(data);
+    options.update(settings);
+  }
+  onMount(() => {
+    datatable.addEventScrollX();
+    datatable.resize();
+    new ResizeObserver((mutations) => {
+      datatable.resize();
+    }).observe(document.querySelector("main.datatable").parentElement);
+  });
+  onDestroy(() => datatable.reset());
 </script>
 
-<main class="datatable">
-    {#if $options.blocks.searchInput === true}
-        <Search/>
-    {/if}
-    <section class="dt-table">
-        <Header/>
-        <table>
-            <slot></slot>
-        </table>
-    </section>
-    {#if $options.blocks.paginationRowCount === true || $options.blocks.paginationButtons === true}
-        <Pagination/>
-    {/if}
-</main>
-
+<section class="datatable">
+  {#if $options.blocks.searchInput === true}
+    <Search />
+  {/if}
+  <section class="dt-table">
+    <Header />
+    <table>
+      <slot />
+    </table>
+  </section>
+  {#if $options.blocks.paginationRowCount === true || $options.blocks.paginationButtons === true}
+    <Pagination />
+  {/if}
+</section>
 
 <style>
-    main{position:relative;background:#fff;height:160px;}
-    main *{box-sizing:border-box;} 
-    section{position:relative;overflow:auto;width:100%;background:inherit;border-bottom:1px solid #e0e0e0;scrollbar-width:thin;}
-    section::-webkit-scrollbar {width:6px;height:6px;}
-    section::-webkit-scrollbar-track {background:#f5f5f5;}
-    section::-webkit-scrollbar-thumb {background:#c2c2c2;}
-    section::-webkit-scrollbar-thumb:hover {background: #9e9e9e;}
-    section::-webkit-scrollbar-track-piece:start {top:40px;}
-    table{width:100%;border-collapse:collapse;overflow:hidden;margin-bottom:6px;}
+  .datatable {
+    position: relative;
+    background: #fff;
+  }
+  .datatable * {
+    box-sizing: border-box;
+  }
+  section {
+    position: relative;
+    overflow: auto;
+    width: 100%;
+    background: inherit;
+    border-bottom: 1px solid #e0e0e0;
+    scrollbar-width: thin;
+  }
+  section::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  section::-webkit-scrollbar-track {
+    background: #f5f5f5;
+  }
+  section::-webkit-scrollbar-thumb {
+    background: #c2c2c2;
+  }
+  section::-webkit-scrollbar-thumb:hover {
+    background: #9e9e9e;
+  }
+  section::-webkit-scrollbar-track-piece:start {
+    top: 40px;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    overflow: hidden;
+    margin-bottom: 6px;
+  }
 </style>

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -1,20 +1,20 @@
 <script>
-  import { options } from "../stores/options.js";
-  import { pageNumber } from "../stores/state.js";
-  import { columns } from "../stores/columns.js";
-  import { local } from "../stores/filters.js";
-  import { data } from "../stores/data.js";
-  import { header } from "./header.js";
-  import { onMount } from "svelte";
-  let theadClassList;
+  import { options } from "../stores/options.js"
+  import { pageNumber } from "../stores/state.js"
+  import { columns } from "../stores/columns.js"
+  import { local } from "../stores/filters.js"
+  import { data } from "../stores/data.js"
+  import { header } from "./header.js"
+  import { onMount } from "svelte"
+  let theadClassList
   onMount(() => {
-    header.getColumns();
-    header.removeOriginalThead();
-    theadClassList = header.getOrginalTHeadClassList();
-  });
+    header.getColumns()
+    header.removeOriginalThead()
+    theadClassList = header.getOrginalTHeadClassList()
+  })
   const sort = (element, key) => {
     if ($options.sortable !== true || typeof key === "undefined") {
-      return;
+      return
     }
     if (
       element.classList.contains("sortable") &&
@@ -22,26 +22,26 @@
     ) {
       Array.from(element.parentNode.children).forEach((item) =>
         item.classList.remove("asc")
-      );
-      element.classList.add("desc");
-      data.sortDesc(key);
-      pageNumber.set(1);
+      )
+      element.classList.add("desc")
+      data.sortDesc(key)
+      pageNumber.set(1)
     } else {
       Array.from(element.parentNode.children).forEach((item) =>
         item.classList.remove("desc")
-      );
-      element.classList.add("asc");
-      data.sortAsc(key);
-      pageNumber.set(1);
+      )
+      element.classList.add("asc")
+      data.sortAsc(key)
+      pageNumber.set(1)
     }
-    columns.redraw();
-  };
+    columns.redraw()
+  }
 
   const filter = (key, value) => {
-    pageNumber.set(1);
-    local.add(key, value);
-    columns.redraw();
-  };
+    pageNumber.set(1)
+    local.add(key, value)
+    columns.redraw()
+  }
 </script>
 
 <section class="datatable-thead" class:sortable={$options.sortable === true}>

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -1,85 +1,152 @@
 <script>
-    import { options } from '../stores/options.js'
-    import { pageNumber } from '../stores/state.js'
-    import { columns } from '../stores/columns.js'
-    import { local } from '../stores/filters.js'
-    import { data } from '../stores/data.js'
-    import { header } from './header.js'
-    import { onMount } from 'svelte'
-    let theadClassList
-    onMount( () => {
-        header.getColumns()
-        header.removeOriginalThead()
-        theadClassList = header.getOrginalTHeadClassList()
-    })
-    const sort = (element, key) => {
-        if($options.sortable !== true || typeof key === 'undefined') {
-            return
-        }
-        if ( element.classList.contains('sortable') && element.classList.contains('asc') ) {
-            Array.from(element.parentNode.children).forEach(item => item.classList.remove('asc'))
-            element.classList.add('desc')
-            data.sortDesc(key)
-            pageNumber.set(1)
-        } else {
-            Array.from(element.parentNode.children).forEach(item => item.classList.remove('desc'))
-            element.classList.add('asc')
-            data.sortAsc(key)
-            pageNumber.set(1)
-        }
-        columns.redraw()
+  import { options } from "../stores/options.js";
+  import { pageNumber } from "../stores/state.js";
+  import { columns } from "../stores/columns.js";
+  import { local } from "../stores/filters.js";
+  import { data } from "../stores/data.js";
+  import { header } from "./header.js";
+  import { onMount } from "svelte";
+  let theadClassList;
+  onMount(() => {
+    header.getColumns();
+    header.removeOriginalThead();
+    theadClassList = header.getOrginalTHeadClassList();
+  });
+  const sort = (element, key) => {
+    if ($options.sortable !== true || typeof key === "undefined") {
+      return;
     }
+    if (
+      element.classList.contains("sortable") &&
+      element.classList.contains("asc")
+    ) {
+      Array.from(element.parentNode.children).forEach((item) =>
+        item.classList.remove("asc")
+      );
+      element.classList.add("desc");
+      data.sortDesc(key);
+      pageNumber.set(1);
+    } else {
+      Array.from(element.parentNode.children).forEach((item) =>
+        item.classList.remove("desc")
+      );
+      element.classList.add("asc");
+      data.sortAsc(key);
+      pageNumber.set(1);
+    }
+    columns.redraw();
+  };
 
-    const filter = (key, value) => {
-        pageNumber.set(1)
-        local.add(key, value)
-        columns.redraw()
-    }
+  const filter = (key, value) => {
+    pageNumber.set(1);
+    local.add(key, value);
+    columns.redraw();
+  };
 </script>
 
 <section class="datatable-thead" class:sortable={$options.sortable === true}>
-    <thead class="{theadClassList}">
-        <tr>
+  <thead class={theadClassList}>
+    <tr>
+      {#each $columns as th}
+        <th
+          nowrap
+          style="min-width:{th.minWidth}px"
+          on:click={(e) => sort(e.target, th.key)}
+          class={th.classList}
+          class:sortable={th.key && $options.sortable === true}
+        >
+          {@html th.html}<span />
+        </th>
+      {/each}
+    </tr>
+    {#if $options.columnFilter === true}
+      <tr>
         {#each $columns as th}
-            <th nowrap
-                style="min-width:{th.minWidth}px" 
-                on:click={(e) => sort(e.target, th.key)}
-                class={th.classList}
-                class:sortable={th.key && $options.sortable === true}
-            >{@html th.html}<span></span></th>
-        {/each}        
-        </tr>
-        {#if $options.columnFilter === true}
-        <tr>
-        {#each $columns as th}
-            <th class="filter" style="width:{th.width};height:25px;">
-                {#if th.key}
-                <input 
-                    type="text" 
-                    placeholder="{$options.labels.filter}" 
-                    class="browser-default"
-                    on:input={(e) => filter(th.key, e.target.value)}
-                />
-                {/if}
-            </th>
+          <th class="filter" style="width:{th.width};height:25px;">
+            {#if th.key}
+              <input
+                type="text"
+                placeholder={$options.labels.filter}
+                class="browser-default"
+                on:input={(e) => filter(th.key, e.target.value)}
+              />
+            {/if}
+          </th>
         {/each}
-        </tr>
-        {/if}
-    </thead>
+      </tr>
+    {/if}
+  </thead>
 </section>
 
 <style>
-    section{position:-webkit-sticky;position:sticky;top:0;left:0;z-index:6;background:inherit;}
-    th{padding:8px 0px 8px 16px;text-align:center;border-bottom:1px solid #eee;background:#fff;}
-    th.sortable{cursor:pointer;}
-    th.sortable span{padding-right:16px;position:relative;}
-    th.sortable span:before,
-    th.sortable span:after {border:4px solid transparent;content:"";display:block;height:0;right:0;top:50%;position:absolute;width:0;}
-    th.sortable span:before {border-bottom-color: #e0e0e0;margin-top: -9px;}
-    th.sortable span:after {border-top-color: #e0e0e0;margin-top: 1px;}
-    th.sortable.asc span:before{border-bottom-color: #9e9e9e;}
-    th.sortable.desc span:after{border-top-color: #9e9e9e;}
-    th.filter{padding:0;margin:0;background-image:none;border:1px solid #fafafa;}
-    th.filter input{background:#fff;padding:0;margin:0;height:24px;width:100%;border:none;border-bottom:1px solid #eee;text-align:center;outline:none;border-radius:0;font-size:14px;}
-    th.filter input::placeholder {color:#bdbdbd;font-style:italic;font-size:13px;}
+  section {
+    position: -webkit-sticky;
+    position: sticky;
+    top: 0;
+    left: 0;
+    z-index: 6;
+    background: inherit;
+  }
+  th {
+    padding: 8px 0px 8px 16px;
+    text-align: center;
+    border-bottom: 1px solid #eee;
+    background: #fff;
+  }
+  th.sortable {
+    cursor: pointer;
+  }
+  th.sortable span {
+    padding-right: 16px;
+    position: relative;
+  }
+  th.sortable span:before,
+  th.sortable span:after {
+    border: 4px solid transparent;
+    content: "";
+    display: block;
+    height: 0;
+    right: 0;
+    top: 50%;
+    position: absolute;
+    width: 0;
+  }
+  th.sortable span:before {
+    border-bottom-color: #e0e0e0;
+    margin-top: -9px;
+  }
+  th.sortable span:after {
+    border-top-color: #e0e0e0;
+    margin-top: 1px;
+  }
+  th.sortable.asc span:before {
+    border-bottom-color: #9e9e9e;
+  }
+  th.sortable.desc span:after {
+    border-top-color: #9e9e9e;
+  }
+  th.filter {
+    padding: 0;
+    margin: 0;
+    background-image: none;
+    border: 1px solid #fafafa;
+  }
+  th.filter input {
+    background: #fff;
+    padding: 0;
+    margin: 0;
+    height: 24px;
+    width: 100%;
+    border: none;
+    border-bottom: 1px solid #eee;
+    text-align: center;
+    outline: none;
+    border-radius: 0;
+    font-size: 14px;
+  }
+  th.filter input::placeholder {
+    color: #bdbdbd;
+    font-style: italic;
+    font-size: 13px;
+  }
 </style>

--- a/src/components/Pagination.svelte
+++ b/src/components/Pagination.svelte
@@ -1,7 +1,7 @@
 <script>
-  import PaginationRowCount from "../PaginationRowCount.svelte";
-  import PaginationButtons from "../PaginationButtons.svelte";
-  import { options } from "../stores/options.js";
+  import PaginationRowCount from "../PaginationRowCount.svelte"
+  import PaginationButtons from "../PaginationButtons.svelte"
+  import { options } from "../stores/options.js"
 </script>
 
 {#if $options.pagination && ($options.blocks.paginationRowCount || $options.blocks.paginationButtons)}

--- a/src/components/Pagination.svelte
+++ b/src/components/Pagination.svelte
@@ -1,22 +1,29 @@
 <script>
-    import PaginationRowCount from '../PaginationRowCount.svelte'
-    import PaginationButtons from '../PaginationButtons.svelte'
-    import { options } from '../stores/options.js'
+  import PaginationRowCount from "../PaginationRowCount.svelte";
+  import PaginationButtons from "../PaginationButtons.svelte";
+  import { options } from "../stores/options.js";
 </script>
 
 {#if $options.pagination && ($options.blocks.paginationRowCount || $options.blocks.paginationButtons)}
-<section class="dt-pagination">
+  <section class="dt-pagination">
     {#if $options.blocks.paginationRowCount}
-        <PaginationRowCount/>
+      <PaginationRowCount />
     {:else}
-        <div></div>
+      <div />
     {/if}
     {#if $options.blocks.paginationButtons}
-        <PaginationButtons/>
+      <PaginationButtons />
     {/if}
-</section>
+  </section>
 {/if}
 
 <style>
-    section{display:flex;flex-direction:row;height:40px;padding-top:8px;justify-content:space-between;background:#fff;}
+  section {
+    display: flex;
+    flex-direction: row;
+    height: 40px;
+    padding-top: 8px;
+    justify-content: space-between;
+    background: #fff;
+  }
 </style>

--- a/src/components/Search.svelte
+++ b/src/components/Search.svelte
@@ -1,12 +1,14 @@
 <script>
-    import { options } from '../stores/options.js'
-    import SearchInput from '../SearchInput.svelte'
+  import SearchInput from "../SearchInput.svelte";
 </script>
 
 <section class="dt-search">
-    <SearchInput/>
+  <SearchInput />
 </section>
 
 <style>
-    section{height:32px;margin-left:16px;}
+  section {
+    height: 32px;
+    margin-left: 16px;
+  }
 </style>

--- a/src/components/Search.svelte
+++ b/src/components/Search.svelte
@@ -1,5 +1,5 @@
 <script>
-  import SearchInput from "../SearchInput.svelte";
+  import SearchInput from "../SearchInput.svelte"
 </script>
 
 <section class="dt-search">


### PR DESCRIPTION
DataTables will often already be inside a `<main>` element, and [shouldn't have more than one that doesn't have hidden attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main) in a document. Changed to `<section>`

Removed the set height on the former `<main>` element, I don't understand why it was there.

Updated dependencies to latest available.

Added Prettier config for consistent formatting.

Expanded CSS for readability.