### PR TITLE
Make section is consistent for all dimensions

### DIFF
--- a/src/components/Pagination.svelte
+++ b/src/components/Pagination.svelte
@@ -23,7 +23,8 @@
         flex-direction: row;
         justify-content: space-between;
         height: 40px;
-        padding-top: 8px;
+        // padding-top: 8px;
+        align-items: center;
     }
     .css{
         background: #fff;


### PR DESCRIPTION
I try to wrap this component on my wrapper element, I found something on the pagination.
Disable the `padding-top`, it makes the UI is not consistent. Use `align-items: center` instead.

### Before

![2021-01-03_08-21](https://user-images.githubusercontent.com/16399020/103469242-42bfc380-4d9d-11eb-86df-4388dd27efa8.png)


### After

![2021-01-03_08-25](https://user-images.githubusercontent.com/16399020/103469246-4d7a5880-4d9d-11eb-9780-0f0b01493d46.png)


