### PR TITLE
Update Colums.js, fix responsive

### DIFF
--- a/src/app/Stores/Columns.js
+++ b/src/app/Stores/Columns.js
@@ -62,16 +62,9 @@ export default class Columns
 							let th = tr.children[i]
 							let thW = th.getBoundingClientRect().width
 							let tdW = td.getBoundingClientRect().width
-							if (tdW > thW) { 
-								th.style.minWidth = tdW + 'px'
-								th.style.maxWidth = tdW + 'px'
-								$columns[i].minWidth = tdW
-							}
-							else {
-								td.style.minWidth = thW + 'px'
-								td.style.maxWidth = thW + 'px'
-								$columns[i].minWidth = thW
-							} 
+							th.style.minWidth = tdW + 'px'
+							th.style.maxWidth = tdW + 'px'
+							$columns[i].minWidth = tdW
 							i++
 						})
 					})

--- a/src/app/Stores/Columns.js
+++ b/src/app/Stores/Columns.js
@@ -62,9 +62,16 @@ export default class Columns
 							let th = tr.children[i]
 							let thW = th.getBoundingClientRect().width
 							let tdW = td.getBoundingClientRect().width
-							th.style.minWidth = tdW + 'px'
-							th.style.maxWidth = tdW + 'px'
-							$columns[i].minWidth = tdW
+							if (tdW > thW) { 
+								th.style.minWidth = tdW + 'px'
+								th.style.maxWidth = tdW + 'px'
+								$columns[i].minWidth = tdW
+							}
+							else {
+								td.style.minWidth = thW + 'px'
+								td.style.maxWidth = thW + 'px'
+								$columns[i].minWidth = thW
+							} 
 							i++
 						})
 					})
@@ -84,16 +91,9 @@ export default class Columns
 							let th = tr.children[i]
 							let thW = th.getBoundingClientRect().width
 							let tdW = td.getBoundingClientRect().width
-							if (tdW > thW) { 
-								th.style.minWidth = tdW + 'px'
-								th.style.maxWidth = tdW + 'px'
-								$columns[i].minWidth = tdW
-							}
-							else {
-								td.style.minWidth = thW + 'px'
-								td.style.maxWidth = thW + 'px'
-								$columns[i].minWidth = thW
-							} 
+							th.style.minWidth = tdW + 'px'
+							th.style.maxWidth = tdW + 'px'
+							$columns[i].minWidth = tdW
 							i++
 						})
 					})


### PR DESCRIPTION
Bonjour.

Je souhaitais utiliser svelte-simple-datatable pour un projet et j'ai remarqué que l'affichage n'était dynamique que dans un sen (lorsque l'on agrandit), j'ai regarder votre code est remarquer que dans le store Columns.js, la fonction redraw utilise des conditions pour le redimensionnement qui font que le référenciel sera toujours la cellule la plus grande entre th et td. j'ai donc enlever les condition et redimensionner toujours suivant  le même type de cellule. L'affichage dynamique marche dans les deux sens maintenant et je n'ai pas trouvé de bugs provoquer par ce changement (si ce n'est que le redimensionnement n'est pas très synchrone lorsque que l'on va vite), je vous laisse voir si vous préféré cette version.

Cordialement. 